### PR TITLE
fix(api): handle urls without resource path properly for reports APIs

### DIFF
--- a/navitia_client/client/apis/line_report_apis.py
+++ b/navitia_client/client/apis/line_report_apis.py
@@ -35,9 +35,10 @@ class LineReportsApiClient(ApiBaseClient):
         forbidden_uris: Optional[Sequence[str]] = None,
         disable_geojson: bool = False,
     ) -> Tuple[Sequence[Disruption], Sequence[LineReport]]:
-        request_url = (
-            f"{self.base_navitia_url}/coverage/{region_id}/{resource_path}/line_reports"
-        )
+        if resource_path:
+            request_url = f"{self.base_navitia_url}/coverage/{region_id}/{resource_path}/line_reports"
+        else:
+            request_url = f"{self.base_navitia_url}/coverage/{region_id}/line_reports"
 
         filters = {
             "count": count,

--- a/navitia_client/client/apis/traffic_report_apis.py
+++ b/navitia_client/client/apis/traffic_report_apis.py
@@ -38,7 +38,12 @@ class TrafficReportsApiClient(ApiBaseClient):
         forbidden_uris: Optional[Sequence[str]] = None,
         disable_geojson: bool = False,
     ) -> Tuple[Sequence[Disruption], Sequence[TrafficReport], Pagination]:
-        request_url = f"{self.base_navitia_url}/coverage/{region_id}/{resource_path}/traffic_reports"
+        if resource_path:
+            request_url = f"{self.base_navitia_url}/coverage/{region_id}/{resource_path}/traffic_reports"
+        else:
+            request_url = (
+                f"{self.base_navitia_url}/coverage/{region_id}/traffic_reports"
+            )
 
         filters = {
             "count": count,


### PR DESCRIPTION
* Update TraffictReportsApiClient
* Update LineReportsApiClient