### PR TITLE
fix(arrays): fix arrays handling when building filter query before calling navitia APIs

### DIFF
--- a/navitia_client/client/apis/api_base_client.py
+++ b/navitia_client/client/apis/api_base_client.py
@@ -43,8 +43,15 @@ class ApiBaseClient:
     @staticmethod
     def _generate_filter_query(filters: dict[str, Any]) -> str:
         """Generate query string regarding provided filters"""
-        filter_query = "&".join([f"{key}={value}" for key, value in filters.items()])
-        return "?" + filter_query if filter_query else ""
+        filter_query = ""
+        for key, value in filters.items():
+            if isinstance(value, list):
+                filter_query += "".join(
+                    f"&{key}={individual_value}" for individual_value in value
+                )
+            else:
+                filter_query += f"&{key}={value}"
+        return "?" + filter_query[1:] if len(filter_query) > 0 else ""
 
     def get_navitia_api(self, endpoint: str) -> Response:
         return self._check_response_for_exception(self.session.get(endpoint))

--- a/tests/client/apis/test_api_base_client.py
+++ b/tests/client/apis/test_api_base_client.py
@@ -63,3 +63,68 @@ def test_check_response_for_exception(api_base_client: ApiBaseClient) -> None:
     # When/Then
     with pytest.raises(NavitiaForbiddenAccessError):
         api_base_client._check_response_for_exception(response)
+
+
+def test_generate_filter_query(api_base_client: ApiBaseClient) -> None:
+    # Given
+    filters = {
+        "start_page": 0,
+        "count": 25,
+        "depth": 1,
+    }
+
+    expected_filters_string = "?start_page=0&count=25&depth=1"
+
+    # When
+    generated_filters_string = api_base_client._generate_filter_query(filters)
+
+    # Then
+    assert expected_filters_string == generated_filters_string
+
+
+def test_generate_filter_query_no_filters(api_base_client: ApiBaseClient) -> None:
+    # Given
+    filters = {}  # type: ignore
+
+    expected_filters_string = ""
+
+    # When
+    generated_filters_string = api_base_client._generate_filter_query(filters)
+
+    # Then
+    assert expected_filters_string == generated_filters_string
+
+
+def test_generate_filter_query_arg_is_list(api_base_client: ApiBaseClient) -> None:
+    # Given
+    filters = {
+        "start_page": 0,
+        "count": 25,
+        "depth": 1,
+        "type[]": ["stop_point", "stop_area"],
+    }
+
+    expected_filters_string = (
+        "?start_page=0&count=25&depth=1&type[]=stop_point&type[]=stop_area"
+    )
+
+    # When
+    generated_filters_string = api_base_client._generate_filter_query(filters)
+
+    # Then
+    assert expected_filters_string == generated_filters_string
+
+
+def test_generate_filter_query_arg_list_is_empty(
+    api_base_client: ApiBaseClient,
+) -> None:
+    # Given
+    filters = {"start_page": 0, "count": 25, "depth": 1, "type[]": []}
+
+    expected_filters_string = "?start_page=0&count=25&depth=1"
+
+    # When
+    generated_filters_string = api_base_client._generate_filter_query(filters)
+
+    # Then
+    assert expected_filters_string == generated_filters_string


### PR DESCRIPTION
Navitia APIs does not accept list as args (foo[]=[bar, fuzz]).

This PR update the _generate_filter_query method to return supported query string (foo[]=bar&foo[]=fuzz).