### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit_ci.yaml
+++ b/.github/workflows/pre-commit_ci.yaml
@@ -2,6 +2,10 @@ name: Pre Commit CI
 
 on: pull_request
 
+permissions:
+  contents: read
+
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [prereleased]
 
+permissions:
+  contents: read
+
 jobs:
   pre-release-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: read
+
 jobs:
   release-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,9 @@ name: Test code
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jonperron/python-navitia-client/security/code-scanning/1](https://github.com/jonperron/python-navitia-client/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since this is a basic CI pipeline for testing Python code, the workflow only needs read access to the repository contents. We will set `contents: read` as the minimal required permission. This change will ensure that the workflow adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
